### PR TITLE
feat(operator): make preview domain configurable via PREVIEW_DOMAIN env var

### DIFF
--- a/charts/catalyst/templates/operator-deployment.yaml
+++ b/charts/catalyst/templates/operator-deployment.yaml
@@ -72,6 +72,10 @@ spec:
           env:
             - name: LOCAL_PREVIEW_ROUTING
               value: {{ .Values.operator.localPreviewRouting | quote }}
+            {{- if .Values.operator.previewDomain }}
+            - name: PREVIEW_DOMAIN
+              value: {{ .Values.operator.previewDomain | quote }}
+            {{- end }}
             {{- if .Values.operator.ingressPort }}
             - name: INGRESS_PORT
               value: {{ .Values.operator.ingressPort | quote }}

--- a/operator/internal/controller/deploy.go
+++ b/operator/internal/controller/deploy.go
@@ -108,7 +108,7 @@ func desiredService(namespace string) *corev1.Service {
 // desiredIngress creates an Ingress resource for the environment.
 // When isLocal is true, it uses hostname-based routing with *.localhost (e.g., namespace.localhost:8080).
 // When isLocal is false, it uses hostname-based routing with TLS (production mode).
-func desiredIngress(env *catalystv1alpha1.Environment, namespace string, isLocal bool) *networkingv1.Ingress {
+func desiredIngress(env *catalystv1alpha1.Environment, namespace string, isLocal bool, previewDomain ...string) *networkingv1.Ingress {
 	if isLocal {
 		// Hostname-based routing for local development
 		// Pattern: namespace.localhost (e.g., catalyst-catalyst-dev.localhost:8080)
@@ -151,8 +151,11 @@ func desiredIngress(env *catalystv1alpha1.Environment, namespace string, isLocal
 	}
 
 	// Production mode: hostname-based routing with TLS
-	// Host format: <env-name>.preview.catalyst.dev
-	host := fmt.Sprintf("%s.preview.catalyst.dev", env.Name)
+	domain := "preview.catalyst.dev"
+	if len(previewDomain) > 0 && previewDomain[0] != "" {
+		domain = previewDomain[0]
+	}
+	host := fmt.Sprintf("%s.%s", env.Name, domain)
 	pathType := networkingv1.PathTypePrefix
 
 	return &networkingv1.Ingress{
@@ -201,7 +204,7 @@ func desiredIngress(env *catalystv1alpha1.Environment, namespace string, isLocal
 // generateURL creates the public URL for the environment based on the deployment mode.
 // When isLocal is true, it generates a hostname-based URL (e.g., http://namespace.localhost:8080/).
 // When isLocal is false, it generates a hostname-based URL with HTTPS (e.g., https://env-name.preview.catalyst.dev/).
-func generateURL(env *catalystv1alpha1.Environment, namespace string, isLocal bool, ingressPort string) string {
+func generateURL(env *catalystv1alpha1.Environment, namespace string, isLocal bool, ingressPort string, previewDomain ...string) string {
 	if isLocal {
 		// Hostname-based URL for local development
 		// Default ingress port is 8080 if not specified
@@ -212,7 +215,11 @@ func generateURL(env *catalystv1alpha1.Environment, namespace string, isLocal bo
 	}
 
 	// Production hostname-based URL with HTTPS
-	return fmt.Sprintf("https://%s.preview.catalyst.dev/", env.Name)
+	domain := "preview.catalyst.dev"
+	if len(previewDomain) > 0 && previewDomain[0] != "" {
+		domain = previewDomain[0]
+	}
+	return fmt.Sprintf("https://%s.%s/", env.Name, domain)
 }
 
 func toCoreEnvVars(vars []catalystv1alpha1.EnvVar) []corev1.EnvVar {

--- a/operator/internal/controller/deploy_test.go
+++ b/operator/internal/controller/deploy_test.go
@@ -86,7 +86,7 @@ func TestDesiredIngress_ProductionMode(t *testing.T) {
 	namespace := "my-project-test-env"
 	isLocal := false
 
-	ingress := desiredIngress(env, namespace, isLocal)
+	ingress := desiredIngress(env, namespace, isLocal, "preview.tetraship.app")
 
 	// Verify basic metadata
 	assert.Equal(t, "app", ingress.Name)
@@ -100,7 +100,7 @@ func TestDesiredIngress_ProductionMode(t *testing.T) {
 	// Verify TLS configuration
 	assert.Len(t, ingress.Spec.TLS, 1)
 	tls := ingress.Spec.TLS[0]
-	expectedHost := "test-env.preview.catalyst.dev"
+	expectedHost := "test-env.preview.tetraship.app"
 	assert.Equal(t, []string{expectedHost}, tls.Hosts)
 	assert.Equal(t, "test-env-tls", tls.SecretName)
 
@@ -152,12 +152,12 @@ func TestGenerateURL_ProductionMode(t *testing.T) {
 	namespace := "my-project-test-env"
 	isLocal := false
 
-	url := generateURL(env, namespace, isLocal, "")
-	assert.Equal(t, "https://test-env.preview.catalyst.dev/", url)
+	url := generateURL(env, namespace, isLocal, "", "preview.tetraship.app")
+	assert.Equal(t, "https://test-env.preview.tetraship.app/", url)
 
 	// Port should be ignored in production mode
-	url = generateURL(env, namespace, isLocal, "9090")
-	assert.Equal(t, "https://test-env.preview.catalyst.dev/", url)
+	url = generateURL(env, namespace, isLocal, "9090", "preview.tetraship.app")
+	assert.Equal(t, "https://test-env.preview.tetraship.app/", url)
 }
 
 func TestGetImageForDeployment_FromSpec(t *testing.T) {

--- a/operator/internal/controller/environment_controller.go
+++ b/operator/internal/controller/environment_controller.go
@@ -242,8 +242,9 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Determine if we're in local mode (path-based routing) or production mode (hostname-based routing)
 	isLocal := os.Getenv("LOCAL_PREVIEW_ROUTING") == "true"
 	ingressPort := os.Getenv("INGRESS_PORT")
+	previewDomain := os.Getenv("PREVIEW_DOMAIN")
 
-	ingress := desiredIngress(env, targetNamespace, isLocal)
+	ingress := desiredIngress(env, targetNamespace, isLocal, previewDomain)
 	existingIngress := &networkingv1.Ingress{}
 	err = r.Get(ctx, client.ObjectKey{Name: "app", Namespace: targetNamespace}, existingIngress)
 
@@ -258,7 +259,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Generate and update the URL in status
-	publicURL := generateURL(env, targetNamespace, isLocal, ingressPort)
+	publicURL := generateURL(env, targetNamespace, isLocal, ingressPort, previewDomain)
 	if env.Status.URL != publicURL {
 		env.Status.URL = publicURL
 		log.Info("Updating Environment URL", "url", publicURL)


### PR DESCRIPTION
## Summary
- Replace hardcoded `preview.catalyst.dev` domain in operator with configurable `PREVIEW_DOMAIN` env var
- Add `PREVIEW_DOMAIN` env var to operator Helm chart template, read from `operator.previewDomain` values
- Falls back to `preview.catalyst.dev` if env var is not set
- Update tests to use `preview.tetraship.app` domain

## Test plan
- [x] Go unit tests pass (`TestDesiredIngress_ProductionMode`, `TestGenerateURL_ProductionMode`)
- [ ] CI passes
- [ ] Deploy with `operator.previewDomain: preview.tetraship.app` and verify environment URLs use correct domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)