### PR TITLE
feat(health): add liveness endpoint, fix probe configuration

### DIFF
--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -114,10 +114,10 @@ web:
 
   livenessProbe:
     httpGet:
-      path: /api/health/readiness
+      path: /api/health/liveness
       port: http
     initialDelaySeconds: 10
-    periodSeconds: 10
+    periodSeconds: 15
 
   readinessProbe:
     httpGet:

--- a/charts/nextjs/values.yaml
+++ b/charts/nextjs/values.yaml
@@ -173,7 +173,7 @@ resources:
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
-    path: /api/health/readiness
+    path: /api/health/liveness
     port: http
 readinessProbe:
   httpGet:

--- a/operator/internal/controller/deploy.go
+++ b/operator/internal/controller/deploy.go
@@ -69,6 +69,28 @@ func desiredDeployment(env *catalystv1alpha1.Environment, namespace string) *app
 								{ContainerPort: 3000},
 							},
 							Env: toCoreEnvVars(env.Spec.Config.EnvVars),
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/api/health/liveness",
+										Port: intstr.FromInt(3000),
+									},
+								},
+								InitialDelaySeconds: 10,
+								PeriodSeconds:       15,
+								TimeoutSeconds:      5,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/api/health/readiness",
+										Port: intstr.FromInt(3000),
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+								TimeoutSeconds:      5,
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/operator/internal/controller/development_deploy.go
+++ b/operator/internal/controller/development_deploy.go
@@ -386,11 +386,11 @@ func desiredDevelopmentDeployment(env *catalystv1alpha1.Environment, project *ca
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/",
+										Path: "/api/health/liveness",
 										Port: intstr.FromInt(3000),
 									},
 								},
-								InitialDelaySeconds: 5,
+								InitialDelaySeconds: 10,
 								PeriodSeconds:       15,
 								TimeoutSeconds:      5,
 							},

--- a/web/src/app/api/health/liveness/route.ts
+++ b/web/src/app/api/health/liveness/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "ok" });
+}


### PR DESCRIPTION
## Summary
- Add `/api/health/liveness` endpoint — lightweight health check (no DB query), returns `{"status":"ok"}`
- Add liveness + readiness probes to operator's deployment environments (`deploy.go`) which previously had none
- Fix development environment liveness probe: was hitting `/` (full page render), now uses `/api/health/liveness`
- Update Helm chart defaults (`catalyst`, `nextjs`) to use `/api/health/liveness` for liveness probes

## Test plan
- [x] Operator Go tests pass
- [ ] CI passes
- [ ] Deploy and verify pods pass health checks without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)