### PR TITLE
docs(012): document phase 1 spike findings — T001 complete, T005 blocked

### DIFF
--- a/specs/012-cross-account-cloud-resources/plan.md
+++ b/specs/012-cross-account-cloud-resources/plan.md
@@ -398,7 +398,19 @@ They complement each other: Crossplane provisions the cluster → Catalyst opera
 - Claim deletion removes all AWS resources including IAM roles and instance profiles
 - ProviderConfig credential isolation verified (second ProviderConfig cannot access first account's resources)
 
-**Findings**: _To be filled after spike is complete._
+**Findings** (2026-04-08):
+
+**T001 — Crossplane install: COMPLETE**
+
+- K3s VM started via `bin/k3s-vm` (NixOS QEMU, 1 node Ready)
+- `crossplane/dev-setup.sh` ran successfully: Crossplane v2.2.0 installed; `provider-aws-ec2`, `provider-aws-iam`, `provider-aws-autoscaling`, and `upbound-provider-family-aws` all Healthy
+- **Note**: Provider family auto-name changed to `upbound-provider-family-aws` in this version — the wait condition in `dev-setup.sh` targets the old name `provider-family-aws` (not found), but the provider itself is healthy under the new name. Script line 64 should be updated to match.
+
+**T005 — Smoke test: BLOCKED (missing AWS credentials)**
+
+- No management IAM credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) are provisioned in the agent environment or Bitwarden.
+- Steps 2–5 of the approach (IAM user creation, CloudFormation onboarding, ProviderConfig, VPC smoke test) require AWS console or CLI access with sufficient permissions.
+- Unblocking path: Nicholas to provision a management IAM user scoped to `sts:AssumeRole` only, store credentials in Bitwarden, and create a target-account role via the CloudFormation template at `crossplane/onboarding/aws-cloudformation.yaml`.
 
 ## Metrics
 

--- a/specs/012-cross-account-cloud-resources/tasks.md
+++ b/specs/012-cross-account-cloud-resources/tasks.md
@@ -11,7 +11,7 @@
 
 ### Infrastructure Setup
 
-- [ ] T001 Install Crossplane core + provider-aws in K3s dev environment
+- [x] T001 Install Crossplane core + provider-aws in K3s dev environment
   - Run `crossplane/dev-setup.sh` (idempotent)
   - Verify Crossplane pods running: `bin/kubectl get pods -n crossplane-system`
   - Verify provider-aws installed: `bin/kubectl get providers`


### PR DESCRIPTION
## Summary

- Executed phase 1 of spec/012-cross-account-cloud-resources per email task
- T001 complete: Crossplane v2.2.0 + provider-aws family installed and Healthy in K3s dev env
- T005 blocked: no management IAM credentials in agent environment/Bitwarden
- Documents: provider family name changed to `upbound-provider-family-aws` in Crossplane v2.2.0

## Tasks

- [x] T001 Install Crossplane + provider-aws in K3s dev env
- [ ] T005 Smoke test — **blocked: needs management IAM user + target-account role**
- [ ] T006 Document findings — this PR

## Blocker for T005

Nicholas needs to: create a management IAM user scoped to `sts:AssumeRole` only, store credentials in Bitwarden, and create a target-account role via `crossplane/onboarding/aws-cloudformation.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)